### PR TITLE
Implementing a relative time formatter with each task

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1531,9 +1531,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1546,9 +1543,6 @@
       "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1563,9 +1557,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1579,9 +1570,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1592,7 +1580,6 @@
       "version": "4.60.4",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
       "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
-<<<<<<< Updated upstream
       "cpu": [
         "loong64"
       ],
@@ -1606,29 +1593,8 @@
       "version": "4.60.4",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
       "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
-=======
->>>>>>> Stashed changes
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
-      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
-      "cpu": [
-        "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1640,7 +1606,6 @@
       "version": "4.60.4",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
       "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
-<<<<<<< Updated upstream
       "cpu": [
         "ppc64"
       ],
@@ -1654,29 +1619,8 @@
       "version": "4.60.4",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
       "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
-=======
->>>>>>> Stashed changes
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
-      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
-      "cpu": [
-        "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1691,9 +1635,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1706,9 +1647,6 @@
       "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1723,9 +1661,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1739,9 +1674,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1754,9 +1686,6 @@
       "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2923,7 +2852,8 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.4.3.tgz",
       "integrity": "sha512-N+3IGQ3HPlyO2YAkntGAwitm42BpBGV86MttzUMiRzWLa4NGh0pltVRcUVF4ybL/OnXjCrr9k7SDPIKkFYP2Lg==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/dexie-react-hooks": {
       "version": "4.4.0",

--- a/src/components/Task/Task.jsx
+++ b/src/components/Task/Task.jsx
@@ -38,8 +38,6 @@ export default function Task({ task, sectionId, deleteTask, updateTask, onTaskCl
     }, []);
 
     const handleTextChange = (e) => setText(e.target.value);
-
-    
     
     const handleTextBlur = () => {
         setIsEditing(false);
@@ -79,6 +77,29 @@ export default function Task({ task, sectionId, deleteTask, updateTask, onTaskCl
         updateTask(sectionId, task.id, { done: newDone });
     };
 
+    const formatTimeAgo = (timestamp) => {
+        const date = new Date(Number(timestamp) || timestamp);
+        const now = new Date();
+        const diffInSeconds = Math.floor((now - date) / 1000);
+
+        if (diffInSeconds < 60) return `Just Now`;
+        
+        const diffInMinutes = Math.floor(diffInSeconds / 60);
+        if (diffInMinutes < 60) return `${diffInMinutes}m ago`;
+
+        const diffInHours = Math.floor(diffInMinutes / 60);
+        if (diffInHours < 24) return `${diffInHours}h ago`;
+
+        const diffInDays = Math.floor(diffInHours / 24);
+        if (diffInDays < 7) return `${diffInDays}d ago`;
+
+        return date.toLocaleDateString(undefined, {
+            month: "short",
+            day: "numeric",
+            hour: "2-digit",
+            minute: "2-digit"
+        });
+    }
 
     const priorityColor = 
         priority === "high"
@@ -196,18 +217,15 @@ export default function Task({ task, sectionId, deleteTask, updateTask, onTaskCl
             </motion.span>
         )}
             {task.updatedAt && (
-                <span 
-                    className='text-xs' 
-                >
-                    Updated: {new Date(task.updatedAt).toLocaleDateString()}
+                <span className='text-xs text-zinc-500 truncate'>
+                    Updated: {formatTimeAgo(task.updatedAt)}
                 </span>
             )}
 
-            <span 
-                className='text-xs mt-1 text-nowrap'
-            >
-                Created: {new Date(task.id).toLocaleDateString()}
+            <span className='text-xs mt-1 text-zinc-500 truncate'>
+                Created: {formatTimeAgo(task.id)}
             </span>
+
             <AnimatePresence> 
                 {task.description && ( 
                     <motion.p 


### PR DESCRIPTION
## Description
This PR updates the timestamp rendering on the Kanban task cards to use a granular, relative time format (e.g., "Just now", "2h ago") vastly improving the ability to track recent board activity at a glance.

Closes #ISSUE_NUMBER 10

### **Changes Included:**
* **Custom Time Formatter:** Implemented a lightweight, dependency-free `formatTimeAgo` utility function directly in `Task.jsx` to avoid bloating the project with heavy external date libraries.
* **Granular Tracking:** Converts absolute timestamps into highly readable relative times ("Just now", minutes, hours, and days).
* **Graceful Fallback:** For tasks older than 7 days, the formatter falls back to a short absolute date that now explicitly includes the time of day (e.g., "Oct 24, 14:32").
* **UI Safety:** Replaced the previous `.toLocaleDateString()` calls with the new helper. Since the text containers are secured with Tailwind's `truncate`, the UI remains perfectly safe from overflow even when the fallback absolute date is rendered.

### **Testing:**
- [x] Verified recent tasks display relative times correctly ("Just now", "m ago", "h ago", "d ago").
- [x] Verified tasks older than 7 days display the absolute date + time fallback.
- [x] Verified long fallback strings truncate cleanly without breaking the card layout.